### PR TITLE
Python/model index

### DIFF
--- a/src/electos/datamodels/nist/indexes/__init__.py
+++ b/src/electos/datamodels/nist/indexes/__init__.py
@@ -1,1 +1,3 @@
 """Element indexes over models."""
+
+from electos.datamodels.nist.indexes.element_index import ElementIndex

--- a/src/electos/datamodels/nist/indexes/__init__.py
+++ b/src/electos/datamodels/nist/indexes/__init__.py
@@ -1,0 +1,1 @@
+"""Element indexes over models."""

--- a/src/electos/datamodels/nist/indexes/__init__.py
+++ b/src/electos/datamodels/nist/indexes/__init__.py
@@ -1,3 +1,4 @@
 """Element indexes over models."""
 
+from electos.datamodels.nist.indexes.document_index import DocumentIndex
 from electos.datamodels.nist.indexes.element_index import ElementIndex

--- a/src/electos/datamodels/nist/indexes/base.py
+++ b/src/electos/datamodels/nist/indexes/base.py
@@ -1,0 +1,135 @@
+"""Base class of indexes over models."""
+
+from abc import ABCMeta, abstractmethod
+from collections.abc import Sequence, Mapping
+
+from electos.datamodels.nist.models.base import NistModel
+
+
+class IndexBase(metaclass = ABCMeta):
+
+    """Abstract base class for indexes: fast access to elements in a model.
+
+    Currently provides a limited DOM-like interface by '@id' and '@type'.
+    Only elements (mappings) are indexed: Lists and scalars have no
+    '@id' or '@type'.
+
+    Note: This is an *abstract class*. Subclasses should override build indexes.
+    """
+
+    def __init__(self, document, namespace):
+        # Document to index
+        self._document = document
+        # Namespace prefix
+        self._namespace = namespace
+        # Index of elements by '@id'
+        self._by_id = {}
+        # Index of elements by '@type'
+        self._by_type = {}
+        # Generate the indexes
+        self._build_indexes()
+
+
+    # --- IDs
+
+    def ids(self):
+        """Access all element type IDs."""
+        for name in self._by_id:
+            yield name
+
+
+    def by_id(self, id, strict = False):
+        """Access element whose '@id' is 'id'.
+
+        Preserves declaration order of the elements in the model.
+        """
+        id_ = id
+        item = self._by_id.get(id_, None)
+        if not item and strict:
+            raise KeyError(f"No item in index with '@id': {id_}")
+        return item
+
+
+    # --- Types
+
+    def types(self):
+        """Access all element type names."""
+        for name in self._by_type:
+            yield name
+
+
+    def by_type(self, type, strict = False, with_namespace = True):
+        """Access all elements whose '@type' is 'type'.
+
+        Yields: Each element with the given type.
+            The order of the elements in the model is preserved.
+        """
+        type_ = type
+        if with_namespace and "." not in type_:
+            type_ = f"{self._namespace}.{type_}"
+        items = self._by_type.get(type_, [])
+        if not items and strict:
+            raise KeyError(f"No items in index with '@type': {type_}")
+        for item in items:
+            yield item
+
+
+    # --- Internal interface
+
+    def _build_indexes(self):
+        """Build the ID and type indexes."""
+        for item, key, value in self._walk_document(self._document):
+            if not isinstance(value, NistModel):
+                continue
+            node = self._build_node(item, key, value)
+            if hasattr(value, "model__id"):
+                self._by_id[value.model__id] = node
+            if hasattr(value, "model__type"):
+                self._by_type.setdefault(value.model__type, []).append(node)
+
+
+    @abstractmethod
+    def _build_node(self, item, key, value):
+        """Create node that is returned by an index lookup on the key."""
+        pass
+
+
+    def _walk_document(self, parent):
+        """Walk all objects in a document, depth first.
+
+        Yields the objects and their parent objects, to allow basic mutations at
+        each step.
+        - Mappings yield key, value pairs.
+        - Sequences yield index, value pairs.
+        - Scalars yield themselves.
+
+        Parameters:
+            parent: The object being walked.
+
+        Yields:
+            parent: Parent item of the value
+            - For a mapping or sequence: the input 'parent'.
+            - For a scalar: None
+            key: The key used to access the value.
+            - For a mapping: key
+            - For a sequence: numeric index
+            - For a scalar: None
+            value: The value.
+            - For a mapping or sequence: 'parent[key]'
+            - For a scalar: the 'parent'
+        """
+        assert not isinstance(parent, Mapping), \
+              f"There should be no mappings in a model: {parent}\n" \
+              "Did you start indexing from a dictionary instead of a model?"
+        if isinstance(parent, NistModel):
+            for name in parent.__fields__.keys():
+                value = getattr(parent, name)
+                yield parent, name, value
+                yield from self._walk_document(value)
+        elif isinstance(parent, Sequence) and not isinstance(parent, (str, bytes)):
+            for index, value in enumerate(parent):
+                yield parent, index, value
+                yield from self._walk_document(value)
+        else:
+            parent, key, value = None, None, parent
+            yield parent, key, value

--- a/src/electos/datamodels/nist/indexes/base.py
+++ b/src/electos/datamodels/nist/indexes/base.py
@@ -52,20 +52,20 @@ class IndexBase(metaclass = ABCMeta):
 
     # --- Types
 
-    def types(self):
+    def types(self, with_namespace = True):
         """Access all element type names."""
         for name in self._by_type:
-            yield name
+            yield name if with_namespace else name[len(self._namespace) + 1:]
 
 
-    def by_type(self, type, strict = False, with_namespace = True):
+    def by_type(self, type, strict = False):
         """Access all elements whose '@type' is 'type'.
 
         Yields: Each element with the given type.
             The order of the elements in the model is preserved.
         """
         type_ = type
-        if with_namespace and "." not in type_:
+        if "." not in type_:
             type_ = f"{self._namespace}.{type_}"
         items = self._by_type.get(type_, [])
         if not items and strict:

--- a/src/electos/datamodels/nist/indexes/document_index.py
+++ b/src/electos/datamodels/nist/indexes/document_index.py
@@ -1,0 +1,76 @@
+"""Indexes over models that return a context node."""
+
+from electos.datamodels.nist.indexes.base import IndexBase
+
+
+class DocumentIndex(IndexBase):
+
+    """Index that returns model elements directly.
+
+    It does not support mutating the contents after the index is created.
+    """
+
+    """Index that returns context nodes allowing modification of the document.
+
+    Modification means being able to move or remove elements.
+    """
+
+    def _build_node(self, item, key, value):
+        result = IndexNode(item, key, value)
+        return result
+
+
+class IndexNode:
+
+    """Entry in the index describing an item and its container.
+
+    Allows tracking the parent and key of an item so it can be moved or removed.
+    """
+
+    # Note: The field that stores the current item is `value`, *not* `parent`.
+
+    def __init__(self, parent, key, value):
+        """Create an index node.
+
+        Parameters:
+            parent: The container that holds the item with the value.
+                It has one of the following types:
+                - A mapping (a class defined in the JSON Schema)
+                - A sequence (a list)
+            key: The key used to get the value from the parent.
+                If the parent is a mapping the key is the field name.
+                If the parent is a sequence the key is a numeric index.
+            value: The item being examined for reachability.
+                Can be of any type.
+        """
+        self._parent = parent
+        self._key = key
+        self._value = value
+
+
+    def __str__(self):
+        """String form of the item.
+
+        Note: This is not JSON.
+        """
+        return str(self._value)
+
+
+    # Access to properties is read-only.
+
+    @property
+    def parent(self):
+        """Item containing the value."""
+        return self._parent
+
+
+    @property
+    def key(self):
+        """Key (field name or index) used to access the value from the parent."""
+        return self._key
+
+
+    @property
+    def value(self):
+        """Item being examined for reachability."""
+        return self._value

--- a/src/electos/datamodels/nist/indexes/element_index.py
+++ b/src/electos/datamodels/nist/indexes/element_index.py
@@ -1,0 +1,15 @@
+"""Indexes over models that return elements directly."""
+
+from electos.datamodels.nist.indexes.base import IndexBase
+
+
+class ElementIndex(IndexBase):
+
+    """Index that returns model elements directly.
+
+    It does not support mutating the contents after the index is created.
+    """
+
+    def _build_node(self, item, key, value):
+        result = value
+        return result

--- a/test/electos/datamodels/nist/tests/models/cvr/test_cvr_index.py
+++ b/test/electos/datamodels/nist/tests/models/cvr/test_cvr_index.py
@@ -96,34 +96,34 @@ CVR_ID_NAMES_STRICT = [
 
 CVR_ID_TYPES = [
     {
-        "ballot-marker-1": "ReportingDevice",
-        "bedrock-precinct": "GpUnit",
-        "candidate-cosmo-spacely": "Candidate",
-        "candidate-harlan-ellis": "Candidate",
-        "candidate-jane-jetson": "Candidate",
-        "candidate-rudi-indexer": "Candidate",
-        "candidate-spencer-cogswell": "Candidate",
-        "contest-ballot-measure-1--selection-no": "BallotMeasureSelection",
-        "contest-ballot-measure-1--selection-yes": "BallotMeasureSelection",
-        "contest-ballot-measure-gadget-county-1": "BallotMeasureContest",
-        "contest-control-board-spaceport": "CandidateContest",
-        "contest-control-board-spaceport--selection-harlan-ellis": "CandidateSelection",
-        "contest-control-board-spaceport--selection-jane-jetson": "CandidateSelection",
-        "contest-control-board-spaceport--selection-rudi-indexer": "CandidateSelection",
-        "contest-control-board-spaceport--selection-write-in-1": "CandidateSelection",
-        "contest-control-board-spaceport--selection-write-in-2": "CandidateSelection",
-        "contest-mayor--selection-cosmo-spacely": "CandidateSelection",
-        "contest-mayor--selection-spencer-cogswell": "CandidateSelection",
-        "contest-mayor--selection-write-in": "CandidateSelection",
-        "contest-mayor-orbit-city": "CandidateContest",
-        "downtown-precinct": "GpUnit",
-        "gadget-county": "GpUnit",
-        "gadget-county-2021-06": "Election",
-        "party-hadron": "Party",
-        "party-lepton": "Party",
-        "port-precinct": "GpUnit",
-        "snapshot-01": "CVRSnapshot",
-        "spacetown-precinct": "GpUnit",
+        "ballot-marker-1": "CVR.ReportingDevice",
+        "bedrock-precinct": "CVR.GpUnit",
+        "candidate-cosmo-spacely": "CVR.Candidate",
+        "candidate-harlan-ellis": "CVR.Candidate",
+        "candidate-jane-jetson": "CVR.Candidate",
+        "candidate-rudi-indexer": "CVR.Candidate",
+        "candidate-spencer-cogswell": "CVR.Candidate",
+        "contest-ballot-measure-1--selection-no": "CVR.BallotMeasureSelection",
+        "contest-ballot-measure-1--selection-yes": "CVR.BallotMeasureSelection",
+        "contest-ballot-measure-gadget-county-1": "CVR.BallotMeasureContest",
+        "contest-control-board-spaceport": "CVR.CandidateContest",
+        "contest-control-board-spaceport--selection-harlan-ellis": "CVR.CandidateSelection",
+        "contest-control-board-spaceport--selection-jane-jetson": "CVR.CandidateSelection",
+        "contest-control-board-spaceport--selection-rudi-indexer": "CVR.CandidateSelection",
+        "contest-control-board-spaceport--selection-write-in-1": "CVR.CandidateSelection",
+        "contest-control-board-spaceport--selection-write-in-2": "CVR.CandidateSelection",
+        "contest-mayor--selection-cosmo-spacely": "CVR.CandidateSelection",
+        "contest-mayor--selection-spencer-cogswell": "CVR.CandidateSelection",
+        "contest-mayor--selection-write-in": "CVR.CandidateSelection",
+        "contest-mayor-orbit-city": "CVR.CandidateContest",
+        "downtown-precinct": "CVR.GpUnit",
+        "gadget-county": "CVR.GpUnit",
+        "gadget-county-2021-06": "CVR.Election",
+        "party-hadron": "CVR.Party",
+        "party-lepton": "CVR.Party",
+        "port-precinct": "CVR.GpUnit",
+        "snapshot-01": "CVR.CVRSnapshot",
+        "spacetown-precinct": "CVR.GpUnit",
     },
 ]
 
@@ -218,11 +218,9 @@ def test_element_id_invalid_strict(key, value, raises, element_index):
 def test_element_id_types(id_types, element_index):
     expected = id_types
     actual = {}
-    start = len(CVR_NAMESPACE) + 1
     for key in sorted(element_index.ids()):
-        value = element_index.by_id(key)
-        value = value.model__type[start:]
-        actual[key] = value
+        model = element_index.by_id(key)
+        actual[key] = model.model__type
     assert actual == expected
 
 
@@ -258,8 +256,8 @@ def test_element_type_counts(type_counts, element_index):
     actual = {}
     for key in element_index.types():
         items = list(element_index.by_type(key))
-        value = len(items)
-        actual[key] = value
+        count = len(items)
+        actual[key] = count
     assert actual == expected
 
 
@@ -295,11 +293,9 @@ def test_document_id_invalid_strict(key, value, raises, document_index):
 def test_document_id_types(id_types, document_index):
     expected = id_types
     actual = {}
-    start = len(CVR_NAMESPACE) + 1
     for key in document_index.ids():
-        value = document_index.by_id(key).value
-        value = value.model__type[start:]
-        actual[key] = value
+        model = document_index.by_id(key).value
+        actual[key] = model.model__type
     assert actual == expected
 
 
@@ -335,6 +331,6 @@ def test_document_type_counts(type_counts, document_index):
     actual = {}
     for key in document_index.types():
         items = list(document_index.by_type(key))
-        value = len(items)
-        actual[key] = value
+        count = len(items)
+        actual[key] = count
     assert actual == expected

--- a/test/electos/datamodels/nist/tests/models/cvr/test_cvr_index.py
+++ b/test/electos/datamodels/nist/tests/models/cvr/test_cvr_index.py
@@ -169,7 +169,7 @@ def test_element_id_types(id_types, element_index):
     expected = id_types
     actual = {}
     start = len(CVR_NAMESPACE) + 1
-    for key in id_types.keys():
+    for key in sorted(element_index.ids()):
         value = element_index.by_id(key)
         value = value.model__type[start:]
         actual[key] = value
@@ -187,7 +187,7 @@ def test_element_type_names(type_names, element_index):
 def test_element_type_counts(type_counts, element_index):
     expected = type_counts
     actual = {}
-    for key in type_counts.keys():
+    for key in element_index.types():
         items = list(element_index.by_type(key))
         value = len(items)
         actual[key] = value
@@ -208,7 +208,7 @@ def test_document_id_types(id_types, document_index):
     expected = id_types
     actual = {}
     start = len(CVR_NAMESPACE) + 1
-    for key in id_types.keys():
+    for key in document_index.ids():
         value = document_index.by_id(key).value
         value = value.model__type[start:]
         actual[key] = value
@@ -226,7 +226,7 @@ def test_document_type_names(type_names, document_index):
 def test_document_type_counts(type_counts, document_index):
     expected = type_counts
     actual = {}
-    for key in type_counts.keys():
+    for key in document_index.types():
         items = list(document_index.by_type(key))
         value = len(items)
         actual[key] = value

--- a/test/electos/datamodels/nist/tests/models/cvr/test_cvr_index.py
+++ b/test/electos/datamodels/nist/tests/models/cvr/test_cvr_index.py
@@ -149,6 +149,27 @@ CVR_TYPE_NAMES = [
 ]
 
 
+CVR_TYPE_NAMES_WITHOUT_NAMESPACE = [
+    [
+        "BallotMeasureContest",
+        "BallotMeasureSelection",
+        "CVR",
+        "CVRContest",
+        "CVRContestSelection",
+        "CVRSnapshot",
+        "CVRWriteIn",
+        "Candidate",
+        "CandidateContest",
+        "CandidateSelection",
+        "Election",
+        "GpUnit",
+        "Party",
+        "ReportingDevice",
+        "SelectionPosition",
+    ],
+]
+
+
 CVR_TYPE_NAMES_STRICT = [
     # Exists
     (
@@ -182,6 +203,27 @@ CVR_TYPE_COUNTS = [
         "CVR.Party": 2,
         "CVR.ReportingDevice": 1,
         "CVR.SelectionPosition": 10,
+    },
+]
+
+
+CVR_TYPE_COUNTS_WITHOUT_NAMESPACE = [
+    {
+        "BallotMeasureContest": 1,
+        "BallotMeasureSelection": 2,
+        "CVR": 4,
+        "CVRContest": 8,
+        "CVRContestSelection": 10,
+        "CVRSnapshot": 4,
+        "CVRWriteIn": 1,
+        "Candidate": 5,
+        "CandidateContest": 2,
+        "CandidateSelection": 8,
+        "Election": 1,
+        "GpUnit": 5,
+        "Party": 2,
+        "ReportingDevice": 1,
+        "SelectionPosition": 10,
     },
 ]
 
@@ -250,11 +292,29 @@ def test_element_type_names(type_names, element_index):
     assert actual == expected
 
 
+@pytest.mark.parametrize("type_names", CVR_TYPE_NAMES_WITHOUT_NAMESPACE)
+def test_element_type_names_without_namespace(type_names, element_index):
+    expected = type_names
+    actual = sorted(element_index.types(with_namespace = False))
+    assert actual == expected
+
+
 @pytest.mark.parametrize("type_counts", CVR_TYPE_COUNTS)
 def test_element_type_counts(type_counts, element_index):
     expected = type_counts
     actual = {}
     for key in element_index.types():
+        items = list(element_index.by_type(key))
+        count = len(items)
+        actual[key] = count
+    assert actual == expected
+
+
+@pytest.mark.parametrize("type_counts", CVR_TYPE_COUNTS_WITHOUT_NAMESPACE)
+def test_element_type_counts_without_namespace(type_counts, element_index):
+    expected = type_counts
+    actual = {}
+    for key in element_index.types(with_namespace = False):
         items = list(element_index.by_type(key))
         count = len(items)
         actual[key] = count
@@ -325,11 +385,29 @@ def test_document_type_names(type_names, document_index):
     assert actual == expected
 
 
+@pytest.mark.parametrize("type_names", CVR_TYPE_NAMES_WITHOUT_NAMESPACE)
+def test_document_type_names_without_namespace(type_names, document_index):
+    expected = type_names
+    actual = sorted(document_index.types(with_namespace = False))
+    assert actual == expected
+
+
 @pytest.mark.parametrize("type_counts", CVR_TYPE_COUNTS)
 def test_document_type_counts(type_counts, document_index):
     expected = type_counts
     actual = {}
     for key in document_index.types():
+        items = list(document_index.by_type(key))
+        count = len(items)
+        actual[key] = count
+    assert actual == expected
+
+
+@pytest.mark.parametrize("type_counts", CVR_TYPE_COUNTS_WITHOUT_NAMESPACE)
+def test_document_type_counts_without_namespace(type_counts, document_index):
+    expected = type_counts
+    actual = {}
+    for key in document_index.types(with_namespace = False):
         items = list(document_index.by_type(key))
         count = len(items)
         actual[key] = count

--- a/test/electos/datamodels/nist/tests/models/cvr/test_cvr_index.py
+++ b/test/electos/datamodels/nist/tests/models/cvr/test_cvr_index.py
@@ -1,0 +1,194 @@
+import pytest
+
+from electos.datamodels.nist.models.cvr import CastVoteRecordReport
+from electos.datamodels.nist.indexes import ElementIndex
+
+from tests.utility import load_test_json, raises, raises_none
+
+
+# --- Test data
+
+CVR_NAMESPACE = "CVR"
+
+
+CVR_SAMPLE_FILES = [
+    ( "jetsons", "jetsons_main_cvr.json" ),
+]
+
+
+# --- Test fixtures
+
+@pytest.fixture(params = CVR_SAMPLE_FILES)
+def cast_vote_record_report(request):
+    """Pre-load test data and return the cast vote record report."""
+    package, file = request.param
+    data = load_test_json(package, file)
+    result = CastVoteRecordReport(**data)
+    return result
+
+
+@pytest.fixture()
+def element_index(cast_vote_record_report):
+    index = ElementIndex(cast_vote_record_report, CVR_NAMESPACE)
+    return index
+
+
+@pytest.fixture()
+def document_index(cast_vote_record_report):
+    index = DocumentIndex(cast_vote_record_report, CVR_NAMESPACE)
+    return index
+
+
+# --- Test cases
+#
+# Note: Each test case is derived from a 'BallotStyle' in the election report.
+
+CVR_ID_NAMES = [
+    [
+        "ballot-marker-1",
+        "bedrock-precinct",
+        "candidate-cosmo-spacely",
+        "candidate-harlan-ellis",
+        "candidate-jane-jetson",
+        "candidate-rudi-indexer",
+        "candidate-spencer-cogswell",
+        "contest-ballot-measure-1--selection-no",
+        "contest-ballot-measure-1--selection-yes",
+        "contest-ballot-measure-gadget-county-1",
+        "contest-control-board-spaceport",
+        "contest-control-board-spaceport--selection-harlan-ellis",
+        "contest-control-board-spaceport--selection-jane-jetson",
+        "contest-control-board-spaceport--selection-rudi-indexer",
+        "contest-control-board-spaceport--selection-write-in-1",
+        "contest-control-board-spaceport--selection-write-in-2",
+        "contest-mayor--selection-cosmo-spacely",
+        "contest-mayor--selection-spencer-cogswell",
+        "contest-mayor--selection-write-in",
+        "contest-mayor-orbit-city",
+        "downtown-precinct",
+        "gadget-county",
+        "gadget-county-2021-06",
+        "party-hadron",
+        "party-lepton",
+        "port-precinct",
+        "snapshot-01",
+        "spacetown-precinct",
+    ],
+]
+
+
+CVR_ID_TYPES = [
+    {
+        "ballot-marker-1": "ReportingDevice",
+        "bedrock-precinct": "GpUnit",
+        "candidate-cosmo-spacely": "Candidate",
+        "candidate-harlan-ellis": "Candidate",
+        "candidate-jane-jetson": "Candidate",
+        "candidate-rudi-indexer": "Candidate",
+        "candidate-spencer-cogswell": "Candidate",
+        "contest-ballot-measure-1--selection-no": "BallotMeasureSelection",
+        "contest-ballot-measure-1--selection-yes": "BallotMeasureSelection",
+        "contest-ballot-measure-gadget-county-1": "BallotMeasureContest",
+        "contest-control-board-spaceport": "CandidateContest",
+        "contest-control-board-spaceport--selection-harlan-ellis": "CandidateSelection",
+        "contest-control-board-spaceport--selection-jane-jetson": "CandidateSelection",
+        "contest-control-board-spaceport--selection-rudi-indexer": "CandidateSelection",
+        "contest-control-board-spaceport--selection-write-in-1": "CandidateSelection",
+        "contest-control-board-spaceport--selection-write-in-2": "CandidateSelection",
+        "contest-mayor--selection-cosmo-spacely": "CandidateSelection",
+        "contest-mayor--selection-spencer-cogswell": "CandidateSelection",
+        "contest-mayor--selection-write-in": "CandidateSelection",
+        "contest-mayor-orbit-city": "CandidateContest",
+        "downtown-precinct": "GpUnit",
+        "gadget-county": "GpUnit",
+        "gadget-county-2021-06": "Election",
+        "party-hadron": "Party",
+        "party-lepton": "Party",
+        "port-precinct": "GpUnit",
+        "snapshot-01": "CVRSnapshot",
+        "spacetown-precinct": "GpUnit",
+    },
+]
+
+
+CVR_TYPE_NAMES = [
+    [
+        "CVR.BallotMeasureContest",
+        "CVR.BallotMeasureSelection",
+        "CVR.CVR",
+        "CVR.CVRContest",
+        "CVR.CVRContestSelection",
+        "CVR.CVRSnapshot",
+        "CVR.CVRWriteIn",
+        "CVR.Candidate",
+        "CVR.CandidateContest",
+        "CVR.CandidateSelection",
+        "CVR.Election",
+        "CVR.GpUnit",
+        "CVR.Party",
+        "CVR.ReportingDevice",
+        "CVR.SelectionPosition",
+    ],
+]
+
+
+CVR_TYPE_COUNTS = [
+    {
+        "CVR.BallotMeasureContest": 1,
+        "CVR.BallotMeasureSelection": 2,
+        "CVR.CVR": 4,
+        "CVR.CVRContest": 8,
+        "CVR.CVRContestSelection": 10,
+        "CVR.CVRSnapshot": 4,
+        "CVR.CVRWriteIn": 1,
+        "CVR.Candidate": 5,
+        "CVR.CandidateContest": 2,
+        "CVR.CandidateSelection": 8,
+        "CVR.Election": 1,
+        "CVR.GpUnit": 5,
+        "CVR.Party": 2,
+        "CVR.ReportingDevice": 1,
+        "CVR.SelectionPosition": 10,
+    },
+]
+
+
+# --- Tests
+
+# Element Index
+
+@pytest.mark.parametrize("id_names", CVR_ID_NAMES)
+def test_element_id_names(id_names, element_index):
+    expected = id_names
+    actual = sorted(element_index.ids())
+    assert actual == expected
+
+
+@pytest.mark.parametrize("id_types", CVR_ID_TYPES)
+def test_element_id_types(id_types, element_index):
+    expected = id_types
+    actual = {}
+    start = len(CVR_NAMESPACE) + 1
+    for key in id_types.keys():
+        value = element_index.by_id(key)
+        value = value.model__type[start:]
+        actual[key] = value
+    assert actual == expected
+
+
+@pytest.mark.parametrize("type_names", CVR_TYPE_NAMES)
+def test_element_type_names(type_names, element_index):
+    expected = type_names
+    actual = sorted(element_index.types())
+    assert actual == expected
+
+
+@pytest.mark.parametrize("type_counts", CVR_TYPE_COUNTS)
+def test_element_type_counts(type_counts, element_index):
+    expected = type_counts
+    actual = {}
+    for key in type_counts.keys():
+        items = list(element_index.by_type(key))
+        value = len(items)
+        actual[key] = value
+    assert actual == expected

--- a/test/electos/datamodels/nist/tests/models/cvr/test_cvr_index.py
+++ b/test/electos/datamodels/nist/tests/models/cvr/test_cvr_index.py
@@ -1,5 +1,6 @@
 import pytest
 
+from electos.datamodels.nist.models.base import NistModel
 from electos.datamodels.nist.models.cvr import CastVoteRecordReport
 from electos.datamodels.nist.indexes import DocumentIndex, ElementIndex
 
@@ -77,6 +78,22 @@ CVR_ID_NAMES = [
 ]
 
 
+CVR_ID_NAMES_STRICT = [
+    # Exists
+    (
+        "downtown-precinct",
+        "CVR.GpUnit",
+        raises_none(),
+    ),
+    # Doesn't exist
+    (
+        "uptown-precinct",
+        None,
+        raises(KeyError),
+    ),
+]
+
+
 CVR_ID_TYPES = [
     {
         "ballot-marker-1": "ReportingDevice",
@@ -132,6 +149,22 @@ CVR_TYPE_NAMES = [
 ]
 
 
+CVR_TYPE_NAMES_STRICT = [
+    # Exists
+    (
+        "CVR.GpUnit",
+        "CVR.GpUnit",
+        raises_none(),
+    ),
+    # Doesn't exist
+    (
+        "NotARealType",
+        [],
+        raises(KeyError),
+    ),
+]
+
+
 CVR_TYPE_COUNTS = [
     {
         "CVR.BallotMeasureContest": 1,
@@ -164,6 +197,23 @@ def test_element_id_names(id_names, element_index):
     assert actual == expected
 
 
+@pytest.mark.parametrize("key, value, raises", CVR_ID_NAMES_STRICT)
+def test_element_id_invalid_not_strict(key, value, raises, element_index):
+    expected = value
+    model = element_index.by_id(key)
+    actual = model.model__type if isinstance(model, NistModel) else model
+    assert actual == expected
+
+
+@pytest.mark.parametrize("key, value, raises", CVR_ID_NAMES_STRICT)
+def test_element_id_invalid_strict(key, value, raises, element_index):
+    expected = value
+    with raises:
+        model = element_index.by_id(key, strict = True)
+        actual = model.model__type if isinstance(model, NistModel) else model
+        assert actual == expected
+
+
 @pytest.mark.parametrize("id_types", CVR_ID_TYPES)
 def test_element_id_types(id_types, element_index):
     expected = id_types
@@ -174,6 +224,25 @@ def test_element_id_types(id_types, element_index):
         value = value.model__type[start:]
         actual[key] = value
     assert actual == expected
+
+
+@pytest.mark.parametrize("key, value, raises", CVR_TYPE_NAMES_STRICT)
+def test_element_type_invalid_not_strict(key, value, raises, element_index):
+    expected = value
+    models = list(element_index.by_type(key))
+    actual = models[0].model__type \
+        if models and isinstance(models[0], NistModel) else models
+    assert actual == expected
+
+
+@pytest.mark.parametrize("key, value, raises", CVR_TYPE_NAMES_STRICT)
+def test_element_type_invalid_strict(key, value, raises, element_index):
+    expected = value
+    with raises:
+        models = list(element_index.by_type(key, strict = True))
+        actual = models[0].model__type \
+            if models and isinstance(models[0], NistModel) else models
+        assert actual == expected
 
 
 @pytest.mark.parametrize("type_names", CVR_TYPE_NAMES)
@@ -203,6 +272,25 @@ def test_document_id_names(id_names, document_index):
     assert actual == expected
 
 
+@pytest.mark.parametrize("key, value, raises", CVR_ID_NAMES_STRICT)
+def test_document_id_invalid_not_strict(key, value, raises, document_index):
+    expected = value
+    model = document_index.by_id(key)
+    actual = model.value.model__type \
+        if model and isinstance(model.value, NistModel) else model
+    assert actual == expected
+
+
+@pytest.mark.parametrize("key, value, raises", CVR_ID_NAMES_STRICT)
+def test_document_id_invalid_strict(key, value, raises, document_index):
+    expected = value
+    with raises:
+        model = document_index.by_id(key, strict = True)
+        actual = model.value.model__type \
+            if model and isinstance(model.value, NistModel) else model
+        assert actual == expected
+
+
 @pytest.mark.parametrize("id_types", CVR_ID_TYPES)
 def test_document_id_types(id_types, document_index):
     expected = id_types
@@ -213,6 +301,25 @@ def test_document_id_types(id_types, document_index):
         value = value.model__type[start:]
         actual[key] = value
     assert actual == expected
+
+
+@pytest.mark.parametrize("key, value, raises", CVR_TYPE_NAMES_STRICT)
+def test_document_type_invalid_not_strict(key, value, raises, document_index):
+    expected = value
+    models = list(document_index.by_type(key))
+    actual = models[0].value.model__type \
+        if models and isinstance(models[0].value, NistModel) else models
+    assert actual == expected
+
+
+@pytest.mark.parametrize("key, value, raises", CVR_TYPE_NAMES_STRICT)
+def test_document_type_invalid_strict(key, value, raises, document_index):
+    expected = value
+    with raises:
+        models = list(document_index.by_type(key, strict = True))
+        actual = models[0].value.model__type \
+            if models and isinstance(models[0].value, NistModel) else models
+        assert actual == expected
 
 
 @pytest.mark.parametrize("type_names", CVR_TYPE_NAMES)

--- a/test/electos/datamodels/nist/tests/models/cvr/test_cvr_index.py
+++ b/test/electos/datamodels/nist/tests/models/cvr/test_cvr_index.py
@@ -228,6 +228,42 @@ CVR_TYPE_COUNTS_WITHOUT_NAMESPACE = [
 ]
 
 
+# Note: These tests are just exercising node attributes. The values chosen are
+# for relative ease of review not for any semantic reasons.
+
+CVR_DOCUMENT_INDEX_NODES = [
+    ( "bedrock-precinct", list, 1, "CVR.GpUnit" ),
+    ( "candidate-jane-jetson", list, 2, "CVR.Candidate" ),
+    ( "contest-mayor-orbit-city", list, 0, "CVR.CandidateContest" ),
+    ( "party-hadron", list, 0, "CVR.Party" ),
+    ( "snapshot-01", list, 0, "CVR.CVRSnapshot" ),
+]
+
+
+CVR_DOCUMENT_INDEX_NODE_STRINGS = [
+    (
+        "bedrock-precinct",
+        "model__id='bedrock-precinct' model__type='CVR.GpUnit'"
+    ),
+    (
+        "candidate-jane-jetson",
+        "model__id='candidate-jane-jetson' model__type='CVR.Candidate'"
+    ),
+    (
+        "contest-mayor-orbit-city",
+        "model__id='contest-mayor-orbit-city' model__type='CVR.CandidateContest'"
+    ),
+    (
+        "party-hadron",
+        "model__id='party-hadron' model__type='CVR.Party'"
+    ),
+    (
+        "snapshot-01",
+        "model__id='snapshot-01' model__type='CVR.CVRSnapshot'"
+    ),
+]
+
+
 # --- Tests
 
 # Element Index
@@ -400,6 +436,24 @@ def test_document_type_counts(type_counts, document_index):
         items = list(document_index.by_type(key))
         count = len(items)
         actual[key] = count
+    assert actual == expected
+
+
+# Document IndexNodes
+
+@pytest.mark.parametrize("id, parent_type, key, value_type", CVR_DOCUMENT_INDEX_NODES)
+def test_document_index_node(id, parent_type, key, value_type, document_index):
+    expected = (parent_type, key, value_type)
+    node = document_index.by_id(id)
+    actual = (type(node.parent), node.key, node.value.model__type)
+    assert actual == expected
+
+
+@pytest.mark.parametrize("id, string", CVR_DOCUMENT_INDEX_NODE_STRINGS)
+def test_document_index_node_as_string(id, string, document_index):
+    expected = string
+    node = document_index.by_id(id)
+    actual = " ".join(str(node).split(maxsplit = 2)[0:2])
     assert actual == expected
 
 

--- a/test/electos/datamodels/nist/tests/models/cvr/test_cvr_index.py
+++ b/test/electos/datamodels/nist/tests/models/cvr/test_cvr_index.py
@@ -1,7 +1,7 @@
 import pytest
 
 from electos.datamodels.nist.models.cvr import CastVoteRecordReport
-from electos.datamodels.nist.indexes import ElementIndex
+from electos.datamodels.nist.indexes import DocumentIndex, ElementIndex
 
 from tests.utility import load_test_json, raises, raises_none
 
@@ -189,6 +189,45 @@ def test_element_type_counts(type_counts, element_index):
     actual = {}
     for key in type_counts.keys():
         items = list(element_index.by_type(key))
+        value = len(items)
+        actual[key] = value
+    assert actual == expected
+
+
+# Document Index
+
+@pytest.mark.parametrize("id_names", CVR_ID_NAMES)
+def test_document_id_names(id_names, document_index):
+    expected = id_names
+    actual = sorted(document_index.ids())
+    assert actual == expected
+
+
+@pytest.mark.parametrize("id_types", CVR_ID_TYPES)
+def test_document_id_types(id_types, document_index):
+    expected = id_types
+    actual = {}
+    start = len(CVR_NAMESPACE) + 1
+    for key in id_types.keys():
+        value = document_index.by_id(key).value
+        value = value.model__type[start:]
+        actual[key] = value
+    assert actual == expected
+
+
+@pytest.mark.parametrize("type_names", CVR_TYPE_NAMES)
+def test_document_type_names(type_names, document_index):
+    expected = type_names
+    actual = sorted(document_index.types())
+    assert actual == expected
+
+
+@pytest.mark.parametrize("type_counts", CVR_TYPE_COUNTS)
+def test_document_type_counts(type_counts, document_index):
+    expected = type_counts
+    actual = {}
+    for key in type_counts.keys():
+        items = list(document_index.by_type(key))
         value = len(items)
         actual[key] = value
     assert actual == expected

--- a/test/electos/datamodels/nist/tests/models/edf/test_edf_index.py
+++ b/test/electos/datamodels/nist/tests/models/edf/test_edf_index.py
@@ -1,7 +1,8 @@
 import pytest
 
 from electos.datamodels.nist.models.edf import ElectionReport
-from electos.datamodels.nist.indexes import ElementIndex
+from electos.datamodels.nist.indexes import DocumentIndex, ElementIndex
+from electos.datamodels.nist.indexes.document_index import IndexNode
 
 from tests.utility import load_test_json, raises, raises_none
 
@@ -30,6 +31,12 @@ def election_report(request):
 @pytest.fixture()
 def element_index(election_report):
     index = ElementIndex(election_report, EDF_NAMESPACE)
+    return index
+
+
+@pytest.fixture()
+def document_index(election_report):
+    index = DocumentIndex(election_report, EDF_NAMESPACE)
     return index
 
 
@@ -164,6 +171,8 @@ EDF_TYPE_COUNTS = [
 
 # --- Tests
 
+# Element Index
+
 @pytest.mark.parametrize("id_names", EDF_ID_NAMES)
 def test_element_id_names(id_names, element_index):
     expected = id_names
@@ -177,7 +186,8 @@ def test_element_id_types(id_types, element_index):
     actual = {}
     start = len(EDF_NAMESPACE) + 1
     for key in id_types.keys():
-        value = element_index.by_id(key).model__type[start:]
+        value = element_index.by_id(key)
+        value = value.model__type[start:]
         actual[key] = value
     assert actual == expected
 
@@ -195,6 +205,44 @@ def test_element_type_counts(type_counts, element_index):
     actual = {}
     for key in type_counts.keys():
         items = list(element_index.by_type(key))
+        value = len(items)
+        actual[key] = value
+    assert actual == expected
+
+# Document Index
+
+@pytest.mark.parametrize("id_names", EDF_ID_NAMES)
+def test_document_id_names(id_names, document_index):
+    expected = id_names
+    actual = sorted(document_index.ids())
+    assert actual == expected
+
+
+@pytest.mark.parametrize("id_types", EDF_ID_TYPES)
+def test_document_id_types(id_types, document_index):
+    expected = id_types
+    actual = {}
+    start = len(EDF_NAMESPACE) + 1
+    for key in id_types.keys():
+        value = document_index.by_id(key).value
+        value = value.model__type[start:]
+        actual[key] = value
+    assert actual == expected
+
+
+@pytest.mark.parametrize("type_names", EDF_TYPE_NAMES)
+def test_document_type_names(type_names, document_index):
+    expected = type_names
+    actual = sorted(document_index.types())
+    assert actual == expected
+
+
+@pytest.mark.parametrize("type_counts", EDF_TYPE_COUNTS)
+def test_document_type_counts(type_counts, document_index):
+    expected = type_counts
+    actual = {}
+    for key in type_counts.keys():
+        items = list(document_index.by_type(key))
         value = len(items)
         actual[key] = value
     assert actual == expected

--- a/test/electos/datamodels/nist/tests/models/edf/test_edf_index.py
+++ b/test/electos/datamodels/nist/tests/models/edf/test_edf_index.py
@@ -1,0 +1,200 @@
+import pytest
+
+from electos.datamodels.nist.models.edf import ElectionReport
+from electos.datamodels.nist.indexes import ElementIndex
+
+from tests.utility import load_test_json, raises, raises_none
+
+
+# --- Test data
+
+EDF_NAMESPACE = "ElectionResults"
+
+
+EDF_SAMPLE_FILES = [
+    ( "jetsons", "jetsons_main_edf.json" ),
+]
+
+
+# --- Test fixtures
+
+@pytest.fixture(params = EDF_SAMPLE_FILES)
+def election_report(request):
+    """Pre-load test data and return the election report."""
+    package, file = request.param
+    data = load_test_json(package, file)
+    result = ElectionReport(**data)
+    return result
+
+
+@pytest.fixture()
+def element_index(election_report):
+    index = ElementIndex(election_report, EDF_NAMESPACE)
+    return index
+
+
+
+# --- Test cases
+#
+# Note: Each test case is derived from a 'BallotStyle' in the election report.
+
+EDF_ID_NAMES = [
+    [
+        "ballot-marker-1",
+        "bedrock-precinct",
+        "candidate-cosmo-spacely",
+        "candidate-harlan-ellis",
+        "candidate-jane-jetson",
+        "candidate-rudi-indexer",
+        "candidate-spencer-cogswell",
+        "contest-ballot-measure-gadget-county-1",
+        "contest-ballot-measure-gadget-county-1--selection-no",
+        "contest-ballot-measure-gadget-county-1--selection-yes",
+        "contest-control-board-spaceport",
+        "contest-control-board-spaceport--selection-harlan-ellis",
+        "contest-control-board-spaceport--selection-jane-jetson",
+        "contest-control-board-spaceport--selection-rudi-indexer",
+        "contest-control-board-spaceport--selection-write-in-1",
+        "contest-control-board-spaceport--selection-write-in-2",
+        "contest-mayor--selection-cosmo-spacely",
+        "contest-mayor--selection-spencer-cogswell",
+        "contest-mayor--selection-write-in",
+        "contest-mayor-orbit-city",
+        "downtown-precinct",
+        "gadget-county",
+        "header-ballot-measures",
+        "header-control-board-spaceport",
+        "header-mayor-orbit-city",
+        "party-hadron",
+        "party-lepton",
+        "person-harlan-ellis",
+        "person-jane-jetson",
+        "person-rudy-indexer",
+        "port-precinct",
+        "spacetown-precinct",
+    ],
+]
+
+
+EDF_ID_TYPES = [
+    {
+        "ballot-marker-1": "ReportingDevice",
+        "bedrock-precinct": "ReportingUnit",
+        "candidate-cosmo-spacely": "Candidate",
+        "candidate-harlan-ellis": "Candidate",
+        "candidate-jane-jetson": "Candidate",
+        "candidate-rudi-indexer": "Candidate",
+        "candidate-spencer-cogswell": "Candidate",
+        "contest-ballot-measure-gadget-county-1": "BallotMeasureContest",
+        "contest-ballot-measure-gadget-county-1--selection-no": "BallotMeasureSelection",
+        "contest-ballot-measure-gadget-county-1--selection-yes": "BallotMeasureSelection",
+        "contest-control-board-spaceport": "CandidateContest",
+        "contest-control-board-spaceport--selection-harlan-ellis": "CandidateSelection",
+        "contest-control-board-spaceport--selection-jane-jetson": "CandidateSelection",
+        "contest-control-board-spaceport--selection-rudi-indexer": "CandidateSelection",
+        "contest-control-board-spaceport--selection-write-in-1": "CandidateSelection",
+        "contest-control-board-spaceport--selection-write-in-2": "CandidateSelection",
+        "contest-mayor--selection-cosmo-spacely": "CandidateSelection",
+        "contest-mayor--selection-spencer-cogswell": "CandidateSelection",
+        "contest-mayor--selection-write-in": "CandidateSelection",
+        "contest-mayor-orbit-city": "CandidateContest",
+        "downtown-precinct": "ReportingUnit",
+        "gadget-county": "ReportingUnit",
+        "header-ballot-measures": "Header",
+        "header-control-board-spaceport": "Header",
+        "header-mayor-orbit-city": "Header",
+        "party-hadron": "Party",
+        "party-lepton": "Party",
+        "person-harlan-ellis": "Person",
+        "person-jane-jetson": "Person",
+        "person-rudy-indexer": "Person",
+        "port-precinct": "ReportingUnit",
+        "spacetown-precinct": "ReportingUnit",
+    },
+]
+
+
+EDF_TYPE_NAMES = [
+    [
+        "ElectionResults.BallotMeasureContest",
+        "ElectionResults.BallotMeasureSelection",
+        "ElectionResults.BallotStyle",
+        "ElectionResults.Candidate",
+        "ElectionResults.CandidateContest",
+        "ElectionResults.CandidateSelection",
+        "ElectionResults.DeviceClass",
+        "ElectionResults.Election",
+        "ElectionResults.ExternalIdentifier",
+        "ElectionResults.Header",
+        "ElectionResults.InternationalizedText",
+        "ElectionResults.LanguageString",
+        "ElectionResults.OrderedContest",
+        "ElectionResults.OrderedHeader",
+        "ElectionResults.Party",
+        "ElectionResults.Person",
+        "ElectionResults.ReportingDevice",
+        "ElectionResults.ReportingUnit",
+    ],
+]
+
+
+EDF_TYPE_COUNTS = [
+    {
+        "ElectionResults.BallotMeasureContest": 1,
+        "ElectionResults.BallotMeasureSelection": 2,
+        "ElectionResults.BallotStyle": 4,
+        "ElectionResults.Candidate": 5,
+        "ElectionResults.CandidateContest": 2,
+        "ElectionResults.CandidateSelection": 8,
+        "ElectionResults.DeviceClass": 1,
+        "ElectionResults.Election": 1,
+        "ElectionResults.ExternalIdentifier": 10,
+        "ElectionResults.Header": 3,
+        "ElectionResults.InternationalizedText": 24,
+        "ElectionResults.LanguageString": 24,
+        "ElectionResults.OrderedContest": 8,
+        "ElectionResults.OrderedHeader": 8,
+        "ElectionResults.Party": 2,
+        "ElectionResults.Person": 3,
+        "ElectionResults.ReportingDevice": 1,
+        "ElectionResults.ReportingUnit": 5,
+    },
+]
+
+
+# --- Tests
+
+@pytest.mark.parametrize("id_names", EDF_ID_NAMES)
+def test_element_id_names(id_names, element_index):
+    expected = id_names
+    actual = sorted(element_index.ids())
+    assert actual == expected
+
+
+@pytest.mark.parametrize("id_types", EDF_ID_TYPES)
+def test_element_id_types(id_types, element_index):
+    expected = id_types
+    actual = {}
+    start = len(EDF_NAMESPACE) + 1
+    for key in id_types.keys():
+        value = element_index.by_id(key).model__type[start:]
+        actual[key] = value
+    assert actual == expected
+
+
+@pytest.mark.parametrize("type_names", EDF_TYPE_NAMES)
+def test_element_type_names(type_names, element_index):
+    expected = type_names
+    actual = sorted(element_index.types())
+    assert actual == expected
+
+
+@pytest.mark.parametrize("type_counts", EDF_TYPE_COUNTS)
+def test_element_type_counts(type_counts, element_index):
+    expected = type_counts
+    actual = {}
+    for key in type_counts.keys():
+        items = list(element_index.by_type(key))
+        value = len(items)
+        actual[key] = value
+    assert actual == expected

--- a/test/electos/datamodels/nist/tests/models/edf/test_edf_index.py
+++ b/test/electos/datamodels/nist/tests/models/edf/test_edf_index.py
@@ -250,6 +250,42 @@ EDF_TYPE_COUNTS_WITHOUT_NAMESPACE = [
 ]
 
 
+# Note: These tests are just exercising node attributes. The values chosen are
+# for relative ease of review not for any semantic reasons.
+
+EDF_DOCUMENT_INDEX_NODES = [
+    ( "bedrock-precinct", list, 1, "ElectionResults.ReportingUnit" ),
+    ( "candidate-jane-jetson", list, 2, "ElectionResults.Candidate" ),
+    ( "contest-mayor-orbit-city", list, 0, "ElectionResults.CandidateContest" ),
+    ( "party-hadron", list, 0, "ElectionResults.Party" ),
+    ( "person-harlan-ellis", list, 1, "ElectionResults.Person" ),
+]
+
+
+EDF_DOCUMENT_INDEX_NODE_STRINGS = [
+    (
+        "bedrock-precinct",
+        "model__id='bedrock-precinct' model__type='ElectionResults.ReportingUnit'"
+    ),
+    (
+        "candidate-jane-jetson",
+        "model__id='candidate-jane-jetson' model__type='ElectionResults.Candidate'"
+    ),
+    (
+        "contest-mayor-orbit-city",
+        "model__id='contest-mayor-orbit-city' model__type='ElectionResults.CandidateContest'"
+    ),
+    (
+        "party-hadron",
+        "model__id='party-hadron' model__type='ElectionResults.Party'"
+    ),
+    (
+        "person-harlan-ellis",
+        "model__id='person-harlan-ellis' model__type='ElectionResults.Person'"
+    ),
+]
+
+
 # --- Tests
 
 # Element Index
@@ -422,6 +458,24 @@ def test_document_type_counts(type_counts, document_index):
         items = list(document_index.by_type(key))
         count = len(items)
         actual[key] = count
+    assert actual == expected
+
+
+# Document IndexNodes
+
+@pytest.mark.parametrize("id, parent_type, key, value_type", EDF_DOCUMENT_INDEX_NODES)
+def test_document_index_node(id, parent_type, key, value_type, document_index):
+    expected = (parent_type, key, value_type)
+    node = document_index.by_id(id)
+    actual = (type(node.parent), node.key, node.value.model__type)
+    assert actual == expected
+
+
+@pytest.mark.parametrize("id, string", EDF_DOCUMENT_INDEX_NODE_STRINGS)
+def test_document_index_node_as_string(id, string, document_index):
+    expected = string
+    node = document_index.by_id(id)
+    actual = " ".join(str(node).split(maxsplit = 2)[0:2])
     assert actual == expected
 
 

--- a/test/electos/datamodels/nist/tests/models/edf/test_edf_index.py
+++ b/test/electos/datamodels/nist/tests/models/edf/test_edf_index.py
@@ -162,6 +162,30 @@ EDF_TYPE_NAMES = [
 ]
 
 
+EDF_TYPE_NAMES_WITHOUT_NAMESPACE = [
+    [
+        "BallotMeasureContest",
+        "BallotMeasureSelection",
+        "BallotStyle",
+        "Candidate",
+        "CandidateContest",
+        "CandidateSelection",
+        "DeviceClass",
+        "Election",
+        "ExternalIdentifier",
+        "Header",
+        "InternationalizedText",
+        "LanguageString",
+        "OrderedContest",
+        "OrderedHeader",
+        "Party",
+        "Person",
+        "ReportingDevice",
+        "ReportingUnit",
+    ],
+]
+
+
 EDF_TYPE_NAMES_STRICT = [
     # Exists
     (
@@ -198,6 +222,30 @@ EDF_TYPE_COUNTS = [
         "ElectionResults.Person": 3,
         "ElectionResults.ReportingDevice": 1,
         "ElectionResults.ReportingUnit": 5,
+    },
+]
+
+
+EDF_TYPE_COUNTS_WITHOUT_NAMESPACE = [
+    {
+        "BallotMeasureContest": 1,
+        "BallotMeasureSelection": 2,
+        "BallotStyle": 4,
+        "Candidate": 5,
+        "CandidateContest": 2,
+        "CandidateSelection": 8,
+        "DeviceClass": 1,
+        "Election": 1,
+        "ExternalIdentifier": 10,
+        "Header": 3,
+        "InternationalizedText": 24,
+        "LanguageString": 24,
+        "OrderedContest": 8,
+        "OrderedHeader": 8,
+        "Party": 2,
+        "Person": 3,
+        "ReportingDevice": 1,
+        "ReportingUnit": 5,
     },
 ]
 
@@ -266,11 +314,29 @@ def test_element_type_names(type_names, element_index):
     assert actual == expected
 
 
+@pytest.mark.parametrize("type_names", EDF_TYPE_NAMES_WITHOUT_NAMESPACE)
+def test_element_type_names_without_namespace(type_names, element_index):
+    expected = type_names
+    actual = sorted(element_index.types(with_namespace = False))
+    assert actual == expected
+
+
 @pytest.mark.parametrize("type_counts", EDF_TYPE_COUNTS)
 def test_element_type_counts(type_counts, element_index):
     expected = type_counts
     actual = {}
     for key in element_index.types():
+        items = list(element_index.by_type(key))
+        count = len(items)
+        actual[key] = count
+    assert actual == expected
+
+
+@pytest.mark.parametrize("type_counts", EDF_TYPE_COUNTS_WITHOUT_NAMESPACE)
+def test_element_type_counts_without_namespace(type_counts, element_index):
+    expected = type_counts
+    actual = {}
+    for key in element_index.types(with_namespace = False):
         items = list(element_index.by_type(key))
         count = len(items)
         actual[key] = count
@@ -341,11 +407,29 @@ def test_document_type_names(type_names, document_index):
     assert actual == expected
 
 
+@pytest.mark.parametrize("type_names", EDF_TYPE_NAMES_WITHOUT_NAMESPACE)
+def test_document_type_names_without_namespace(type_names, document_index):
+    expected = type_names
+    actual = sorted(document_index.types(with_namespace = False))
+    assert actual == expected
+
+
 @pytest.mark.parametrize("type_counts", EDF_TYPE_COUNTS)
 def test_document_type_counts(type_counts, document_index):
     expected = type_counts
     actual = {}
     for key in document_index.types():
+        items = list(document_index.by_type(key))
+        count = len(items)
+        actual[key] = count
+    assert actual == expected
+
+
+@pytest.mark.parametrize("type_counts", EDF_TYPE_COUNTS_WITHOUT_NAMESPACE)
+def test_document_type_counts_without_namespace(type_counts, document_index):
+    expected = type_counts
+    actual = {}
+    for key in document_index.types(with_namespace = False):
         items = list(document_index.by_type(key))
         count = len(items)
         actual[key] = count

--- a/test/electos/datamodels/nist/tests/models/edf/test_edf_index.py
+++ b/test/electos/datamodels/nist/tests/models/edf/test_edf_index.py
@@ -1,5 +1,6 @@
 import pytest
 
+from electos.datamodels.nist.models.base import NistModel
 from electos.datamodels.nist.models.edf import ElectionReport
 from electos.datamodels.nist.indexes import DocumentIndex, ElementIndex
 from electos.datamodels.nist.indexes.document_index import IndexNode
@@ -83,6 +84,22 @@ EDF_ID_NAMES = [
 ]
 
 
+EDF_ID_NAMES_STRICT = [
+    # Exists
+    (
+        "downtown-precinct",
+        "ElectionResults.ReportingUnit",
+        raises_none(),
+    ),
+    # Doesn't exist
+    (
+        "uptown-precinct",
+        None,
+        raises(KeyError),
+    ),
+]
+
+
 EDF_ID_TYPES = [
     {
         "ballot-marker-1": "ReportingDevice",
@@ -145,6 +162,22 @@ EDF_TYPE_NAMES = [
 ]
 
 
+EDF_TYPE_NAMES_STRICT = [
+    # Exists
+    (
+        "ElectionResults.ReportingUnit",
+        "ElectionResults.ReportingUnit",
+        raises_none(),
+    ),
+    # Doesn't exist
+    (
+        "NotARealType",
+        [],
+        raises(KeyError),
+    ),
+]
+
+
 EDF_TYPE_COUNTS = [
     {
         "ElectionResults.BallotMeasureContest": 1,
@@ -180,6 +213,23 @@ def test_element_id_names(id_names, element_index):
     assert actual == expected
 
 
+@pytest.mark.parametrize("key, value, raises", EDF_ID_NAMES_STRICT)
+def test_element_id_invalid_not_strict(key, value, raises, element_index):
+    expected = value
+    model = element_index.by_id(key)
+    actual = model.model__type if isinstance(model, NistModel) else model
+    assert actual == expected
+
+
+@pytest.mark.parametrize("key, value, raises", EDF_ID_NAMES_STRICT)
+def test_element_id_invalid_strict(key, value, raises, element_index):
+    expected = value
+    with raises:
+        model = element_index.by_id(key, strict = True)
+        actual = model.model__type if isinstance(model, NistModel) else model
+        assert actual == expected
+
+
 @pytest.mark.parametrize("id_types", EDF_ID_TYPES)
 def test_element_id_types(id_types, element_index):
     expected = id_types
@@ -190,6 +240,25 @@ def test_element_id_types(id_types, element_index):
         value = value.model__type[start:]
         actual[key] = value
     assert actual == expected
+
+
+@pytest.mark.parametrize("key, value, raises", EDF_TYPE_NAMES_STRICT)
+def test_element_type_invalid_not_strict(key, value, raises, element_index):
+    expected = value
+    models = list(element_index.by_type(key))
+    actual = models[0].model__type \
+        if models and isinstance(models[0], NistModel) else models
+    assert actual == expected
+
+
+@pytest.mark.parametrize("key, value, raises", EDF_TYPE_NAMES_STRICT)
+def test_element_type_invalid_strict(key, value, raises, element_index):
+    expected = value
+    with raises:
+        models = list(element_index.by_type(key, strict = True))
+        actual = models[0].model__type \
+            if models and isinstance(models[0], NistModel) else models
+        assert actual == expected
 
 
 @pytest.mark.parametrize("type_names", EDF_TYPE_NAMES)
@@ -219,6 +288,25 @@ def test_document_id_names(id_names, document_index):
     assert actual == expected
 
 
+@pytest.mark.parametrize("key, value, raises", EDF_ID_NAMES_STRICT)
+def test_document_id_invalid_not_strict(key, value, raises, document_index):
+    expected = value
+    model = document_index.by_id(key)
+    actual = model.value.model__type \
+        if model and isinstance(model.value, NistModel) else model
+    assert actual == expected
+
+
+@pytest.mark.parametrize("key, value, raises", EDF_ID_NAMES_STRICT)
+def test_document_id_invalid_strict(key, value, raises, document_index):
+    expected = value
+    with raises:
+        model = document_index.by_id(key, strict = True)
+        actual = model.value.model__type \
+            if model and isinstance(model.value, NistModel) else model
+        assert actual == expected
+
+
 @pytest.mark.parametrize("id_types", EDF_ID_TYPES)
 def test_document_id_types(id_types, document_index):
     expected = id_types
@@ -229,6 +317,25 @@ def test_document_id_types(id_types, document_index):
         value = value.model__type[start:]
         actual[key] = value
     assert actual == expected
+
+
+@pytest.mark.parametrize("key, value, raises", EDF_TYPE_NAMES_STRICT)
+def test_document_type_invalid_not_strict(key, value, raises, document_index):
+    expected = value
+    models = list(document_index.by_type(key))
+    actual = models[0].value.model__type \
+        if models and isinstance(models[0].value, NistModel) else models
+    assert actual == expected
+
+
+@pytest.mark.parametrize("key, value, raises", EDF_TYPE_NAMES_STRICT)
+def test_document_type_invalid_strict(key, value, raises, document_index):
+    expected = value
+    with raises:
+        models = list(document_index.by_type(key, strict = True))
+        actual = models[0].value.model__type \
+            if models and isinstance(models[0].value, NistModel) else models
+        assert actual == expected
 
 
 @pytest.mark.parametrize("type_names", EDF_TYPE_NAMES)

--- a/test/electos/datamodels/nist/tests/models/edf/test_edf_index.py
+++ b/test/electos/datamodels/nist/tests/models/edf/test_edf_index.py
@@ -102,38 +102,38 @@ EDF_ID_NAMES_STRICT = [
 
 EDF_ID_TYPES = [
     {
-        "ballot-marker-1": "ReportingDevice",
-        "bedrock-precinct": "ReportingUnit",
-        "candidate-cosmo-spacely": "Candidate",
-        "candidate-harlan-ellis": "Candidate",
-        "candidate-jane-jetson": "Candidate",
-        "candidate-rudi-indexer": "Candidate",
-        "candidate-spencer-cogswell": "Candidate",
-        "contest-ballot-measure-gadget-county-1": "BallotMeasureContest",
-        "contest-ballot-measure-gadget-county-1--selection-no": "BallotMeasureSelection",
-        "contest-ballot-measure-gadget-county-1--selection-yes": "BallotMeasureSelection",
-        "contest-control-board-spaceport": "CandidateContest",
-        "contest-control-board-spaceport--selection-harlan-ellis": "CandidateSelection",
-        "contest-control-board-spaceport--selection-jane-jetson": "CandidateSelection",
-        "contest-control-board-spaceport--selection-rudi-indexer": "CandidateSelection",
-        "contest-control-board-spaceport--selection-write-in-1": "CandidateSelection",
-        "contest-control-board-spaceport--selection-write-in-2": "CandidateSelection",
-        "contest-mayor--selection-cosmo-spacely": "CandidateSelection",
-        "contest-mayor--selection-spencer-cogswell": "CandidateSelection",
-        "contest-mayor--selection-write-in": "CandidateSelection",
-        "contest-mayor-orbit-city": "CandidateContest",
-        "downtown-precinct": "ReportingUnit",
-        "gadget-county": "ReportingUnit",
-        "header-ballot-measures": "Header",
-        "header-control-board-spaceport": "Header",
-        "header-mayor-orbit-city": "Header",
-        "party-hadron": "Party",
-        "party-lepton": "Party",
-        "person-harlan-ellis": "Person",
-        "person-jane-jetson": "Person",
-        "person-rudy-indexer": "Person",
-        "port-precinct": "ReportingUnit",
-        "spacetown-precinct": "ReportingUnit",
+        "ballot-marker-1": "ElectionResults.ReportingDevice",
+        "bedrock-precinct": "ElectionResults.ReportingUnit",
+        "candidate-cosmo-spacely": "ElectionResults.Candidate",
+        "candidate-harlan-ellis": "ElectionResults.Candidate",
+        "candidate-jane-jetson": "ElectionResults.Candidate",
+        "candidate-rudi-indexer": "ElectionResults.Candidate",
+        "candidate-spencer-cogswell": "ElectionResults.Candidate",
+        "contest-ballot-measure-gadget-county-1": "ElectionResults.BallotMeasureContest",
+        "contest-ballot-measure-gadget-county-1--selection-no": "ElectionResults.BallotMeasureSelection",
+        "contest-ballot-measure-gadget-county-1--selection-yes": "ElectionResults.BallotMeasureSelection",
+        "contest-control-board-spaceport": "ElectionResults.CandidateContest",
+        "contest-control-board-spaceport--selection-harlan-ellis": "ElectionResults.CandidateSelection",
+        "contest-control-board-spaceport--selection-jane-jetson": "ElectionResults.CandidateSelection",
+        "contest-control-board-spaceport--selection-rudi-indexer": "ElectionResults.CandidateSelection",
+        "contest-control-board-spaceport--selection-write-in-1": "ElectionResults.CandidateSelection",
+        "contest-control-board-spaceport--selection-write-in-2": "ElectionResults.CandidateSelection",
+        "contest-mayor--selection-cosmo-spacely": "ElectionResults.CandidateSelection",
+        "contest-mayor--selection-spencer-cogswell": "ElectionResults.CandidateSelection",
+        "contest-mayor--selection-write-in": "ElectionResults.CandidateSelection",
+        "contest-mayor-orbit-city": "ElectionResults.CandidateContest",
+        "downtown-precinct": "ElectionResults.ReportingUnit",
+        "gadget-county": "ElectionResults.ReportingUnit",
+        "header-ballot-measures": "ElectionResults.Header",
+        "header-control-board-spaceport": "ElectionResults.Header",
+        "header-mayor-orbit-city": "ElectionResults.Header",
+        "party-hadron": "ElectionResults.Party",
+        "party-lepton": "ElectionResults.Party",
+        "person-harlan-ellis": "ElectionResults.Person",
+        "person-jane-jetson": "ElectionResults.Person",
+        "person-rudy-indexer": "ElectionResults.Person",
+        "port-precinct": "ElectionResults.ReportingUnit",
+        "spacetown-precinct": "ElectionResults.ReportingUnit",
     },
 ]
 
@@ -234,11 +234,9 @@ def test_element_id_invalid_strict(key, value, raises, element_index):
 def test_element_id_types(id_types, element_index):
     expected = id_types
     actual = {}
-    start = len(EDF_NAMESPACE) + 1
     for key in sorted(element_index.ids()):
-        value = element_index.by_id(key)
-        value = value.model__type[start:]
-        actual[key] = value
+        model = element_index.by_id(key)
+        actual[key] = model.model__type
     assert actual == expected
 
 
@@ -274,8 +272,8 @@ def test_element_type_counts(type_counts, element_index):
     actual = {}
     for key in element_index.types():
         items = list(element_index.by_type(key))
-        value = len(items)
-        actual[key] = value
+        count = len(items)
+        actual[key] = count
     assert actual == expected
 
 
@@ -311,11 +309,9 @@ def test_document_id_invalid_strict(key, value, raises, document_index):
 def test_document_id_types(id_types, document_index):
     expected = id_types
     actual = {}
-    start = len(EDF_NAMESPACE) + 1
     for key in document_index.ids():
-        value = document_index.by_id(key).value
-        value = value.model__type[start:]
-        actual[key] = value
+        model = document_index.by_id(key).value
+        actual[key] = model.model__type
     assert actual == expected
 
 
@@ -351,6 +347,6 @@ def test_document_type_counts(type_counts, document_index):
     actual = {}
     for key in document_index.types():
         items = list(document_index.by_type(key))
-        value = len(items)
-        actual[key] = value
+        count = len(items)
+        actual[key] = count
     assert actual == expected

--- a/test/electos/datamodels/nist/tests/models/edf/test_edf_index.py
+++ b/test/electos/datamodels/nist/tests/models/edf/test_edf_index.py
@@ -185,7 +185,7 @@ def test_element_id_types(id_types, element_index):
     expected = id_types
     actual = {}
     start = len(EDF_NAMESPACE) + 1
-    for key in id_types.keys():
+    for key in sorted(element_index.ids()):
         value = element_index.by_id(key)
         value = value.model__type[start:]
         actual[key] = value
@@ -203,11 +203,12 @@ def test_element_type_names(type_names, element_index):
 def test_element_type_counts(type_counts, element_index):
     expected = type_counts
     actual = {}
-    for key in type_counts.keys():
+    for key in element_index.types():
         items = list(element_index.by_type(key))
         value = len(items)
         actual[key] = value
     assert actual == expected
+
 
 # Document Index
 
@@ -223,7 +224,7 @@ def test_document_id_types(id_types, document_index):
     expected = id_types
     actual = {}
     start = len(EDF_NAMESPACE) + 1
-    for key in id_types.keys():
+    for key in document_index.ids():
         value = document_index.by_id(key).value
         value = value.model__type[start:]
         actual[key] = value
@@ -241,7 +242,7 @@ def test_document_type_names(type_names, document_index):
 def test_document_type_counts(type_counts, document_index):
     expected = type_counts
     actual = {}
-    for key in type_counts.keys():
+    for key in document_index.types():
         items = list(document_index.by_type(key))
         value = len(items)
         actual[key] = value


### PR DESCRIPTION
Allow models to be accessed by DOM-like index interface.

Usage:

Load a document into a model and create an index for the model.

```
from electos.datamodels.nist.models.edf import ElectionReport
from electos.datamodels.nist.indexes import ElementIndex

# Presume 'data' is a dictionary loaded from an EDF JSON file.

election_report = ElectionReport(**data)
index = ElementIndex(election_report, "ElectionResults")
```

Access individual elements with `by_id` (returns a unique element with the given `@id`).
```
ballot_style = index.by_id("ballot_style")
```

Loop through all ids and access them in sequence.
```
for model_id in index.ids():
    element = index.by_id(model_id)
    # Do something with 'element'
```

Access sets of elements with `by_type` (returns an iterable of elements with the given `@type`).
```
ballot_styles = index.by_type("ElectionResults.BallotStyle")
```

Loop through all types and access them in sequence.
```
for model_type in index.types():
    for element in index.by_type(model_type):
        # Do something with 'elements'
```